### PR TITLE
Close sessions no matter what

### DIFF
--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -115,6 +115,7 @@ func (client *client) DeleteSession() error {
 	}
 
 	if client.auth.sid == "" {
+		log.Debug().Msg("Trying to delete empty session")
 		return nil
 	}
 

--- a/internal/pihole/client_test.go
+++ b/internal/pihole/client_test.go
@@ -106,6 +106,12 @@ func (suite *clientTestSuite) TestClient_PatchConfig() {
 	assert.NoError(suite.T(), err)
 }
 
+func (suite *clientTestSuite) TestClient_PostRunGravity() {
+	err := suite.client.PostRunGravity()
+
+	assert.NoError(suite.T(), err)
+}
+
 func TestClient_String(t *testing.T) {
 	piHole := model.NewPiHole("http://asdfasdf.com:1234", apiPassword)
 	s := NewClient(piHole, httpClient).String()

--- a/internal/sync/full.go
+++ b/internal/sync/full.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+
 	"github.com/lovelaze/nebula-sync/internal/config"
 	"github.com/rs/zerolog/log"
 )
@@ -10,6 +11,8 @@ func (target *target) FullSync(syncConf *config.Sync) error {
 	log.Info().Str("mode", "full").Int("replicas", len(target.Replicas)).Msg("Running sync")
 	gravitySettings := newFullSyncGravitySettings()
 	configSettings := newFullSyncConfigSettings()
+
+	defer target.deleteSessions()
 
 	if err := target.authenticate(); err != nil {
 		return fmt.Errorf("authenticate: %w", err)
@@ -28,11 +31,6 @@ func (target *target) FullSync(syncConf *config.Sync) error {
 			return fmt.Errorf("run gravity: %w", err)
 		}
 	}
-
-	if err := target.deleteSessions(); err != nil {
-		return fmt.Errorf("delete sessions: %w", err)
-	}
-
 	return nil
 }
 

--- a/internal/sync/selective.go
+++ b/internal/sync/selective.go
@@ -2,12 +2,15 @@ package sync
 
 import (
 	"fmt"
+
 	"github.com/lovelaze/nebula-sync/internal/config"
 	"github.com/rs/zerolog/log"
 )
 
 func (target *target) SelectiveSync(syncConf *config.Sync) error {
 	log.Info().Str("mode", "selective").Int("replicas", len(target.Replicas)).Msg("Running sync")
+
+	defer target.deleteSessions()
 
 	if err := target.authenticate(); err != nil {
 		return fmt.Errorf("authentication: %w", err)
@@ -26,10 +29,5 @@ func (target *target) SelectiveSync(syncConf *config.Sync) error {
 			return fmt.Errorf("run gravity: %w", err)
 		}
 	}
-
-	if err := target.deleteSessions(); err != nil {
-		return fmt.Errorf("delete sessions: %w", err)
-	}
-
 	return nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -41,21 +41,19 @@ func (target *target) authenticate() (err error) {
 	return err
 }
 
-func (target *target) deleteSessions() (err error) {
+func (target *target) deleteSessions() {
 	log.Info().Msg("Invalidating sessions...")
 	if err := target.Primary.DeleteSession(); err != nil {
-		return err
+		log.Warn().Msgf("Failed to close session for target : %s", target.Primary.String())
 	}
 
 	for _, replica := range target.Replicas {
 		if err := withRetry(func() error {
 			return replica.DeleteSession()
 		}, AttemptsDeleteSession); err != nil {
-			return err
+			log.Warn().Msgf("Failed to close session for target : %s", replica.String())
 		}
 	}
-
-	return err
 }
 
 func (target *target) syncTeleporters(gravitySettings *config.GravitySettings) error {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -122,9 +122,7 @@ func createPatchConfigRequest(config *config.ConfigSettings, configResponse *mod
 	patchConfig := model.PatchConfig{}
 
 	if config.DNS {
-		i := configResponse.Config["dns"]
-		m := i.(map[string]interface{})
-		patchConfig.DNS = m
+		patchConfig.DNS = configResponse.Config["dns"].(map[string]interface{})
 	}
 	if config.DHCP {
 		patchConfig.DHCP = configResponse.Config["dhcp"].(map[string]interface{})

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,12 +1,13 @@
 package sync
 
 import (
+	"testing"
+
 	"github.com/lovelaze/nebula-sync/internal/config"
 	piholemock "github.com/lovelaze/nebula-sync/internal/mocks/pihole"
 	"github.com/lovelaze/nebula-sync/internal/pihole"
 	"github.com/lovelaze/nebula-sync/internal/pihole/model"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_target_authenticate(t *testing.T) {
@@ -37,8 +38,7 @@ func Test_target_deleteSessions(t *testing.T) {
 	primary.EXPECT().DeleteSession().Once().Return(nil)
 	replica.EXPECT().DeleteSession().Once().Return(nil)
 
-	err := target.deleteSessions()
-	assert.NoError(t, err)
+	target.deleteSessions()
 }
 
 func Test_target_syncTeleporters(t *testing.T) {


### PR DESCRIPTION
this fixes #60, 

the case where we flood sessions when an error occurs (session are created but never deleted) resulting in 429 errors on the pihole API



Feel free to edit the PR if anything could be improved 
