### PR TITLE
Add restart to Docker compose example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ services:
   nebula-sync:
     image: ghcr.io/lovelaze/nebula-sync:latest
     container_name: nebula-sync
+    restart: unless-stopped
     environment:
     - PRIMARY=http://ph1.example.com|password
     - REPLICAS=http://ph2.example.com|password,http://ph3.example.com|password


### PR DESCRIPTION
Adding the `restart: unless-stopped` option to the Docker Compose example in the README. I see that this same option is already being added to the `examples/docker-compose.yml` file in #142.