### PR TITLE
feat(config): add support for excluding specific DNS records during sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,22 +116,23 @@ The following environment variables can be specified:
 **Note:** `The SYNC_CONFIG_*_INCLUDE` and `SYNC_CONFIG_*_EXCLUDE` settings are mutually exclusive within each section. Additionally, config filters are only applied if `FULL_SYNC=false`.\
 Config keys are relative to the section and are **case sensitive**. For example, the key `dns.upstreams` should be referred to as `upstreams`, and `dns.cache.size` should be referred to as `cache.size`.
 
-| Name                              | Example                    | Description                                     |
-|-----------------------------------|----------------------------|-------------------------------------------------|
-| `SYNC_CONFIG_DNS_INCLUDE`         | upstreams,interface        | DNS config keys to include                     |
-| `SYNC_CONFIG_DNS_EXCLUDE`         | upstreams,interface        | DNS config keys to exclude                     |
-| `SYNC_CONFIG_DHCP_INCLUDE`        | active,start               | DHCP config keys to include                    |
-| `SYNC_CONFIG_DHCP_EXCLUDE`        | active,start               | DHCP config keys to exclude                    |
-| `SYNC_CONFIG_NTP_INCLUDE`         | ipv4,sync                  | NTP config keys to include                     |
-| `SYNC_CONFIG_NTP_EXCLUDE`         | ipv4,sync                  | NTP config keys to exclude                     |
-| `SYNC_CONFIG_RESOLVER_INCLUDE`    | resolveIPv4,networkNames   | Resolver config keys to include                |
-| `SYNC_CONFIG_RESOLVER_EXCLUDE`    | resolveIPv4,networkNames   | Resolver config keys to exclude                |
-| `SYNC_CONFIG_DATABASE_INCLUDE`    | DBimport,maxDBdays         | Database config keys to include                |
-| `SYNC_CONFIG_DATABASE_EXCLUDE`    | DBimport,maxDBdays         | Database config keys to exclude                |
-| `SYNC_CONFIG_MISC_INCLUDE`        | nice,delay_startup         | Misc config keys to include                    |
-| `SYNC_CONFIG_MISC_EXCLUDE`        | nice,delay_startup         | Misc config keys to exclude                    |
-| `SYNC_CONFIG_DEBUG_INCLUDE`       | database,networking        | Debug config keys to include                   |
-| `SYNC_CONFIG_DEBUG_EXCLUDE`       | database,networking        | Debug config keys to exclude                   |
+| Name                              | Example                    | Description                                                   |
+|-----------------------------------|----------------------------|---------------------------------------------------------------|
+| `SYNC_CONFIG_DNS_INCLUDE`         | upstreams,interface        | DNS config keys to include                                    |
+| `SYNC_CONFIG_DNS_EXCLUDE`         | upstreams,interface        | DNS config keys to exclude                                    |
+| `SYNC_CONFIG_DNS_EXCLUDE_RECORDS` | example.com                | DNS records to exclude from sync (preserves them on replicas) |
+| `SYNC_CONFIG_DHCP_INCLUDE`        | active,start               | DHCP config keys to include                                   |
+| `SYNC_CONFIG_DHCP_EXCLUDE`        | active,start               | DHCP config keys to exclude                                   |
+| `SYNC_CONFIG_NTP_INCLUDE`         | ipv4,sync                  | NTP config keys to include                                    |
+| `SYNC_CONFIG_NTP_EXCLUDE`         | ipv4,sync                  | NTP config keys to exclude                                    |
+| `SYNC_CONFIG_RESOLVER_INCLUDE`    | resolveIPv4,networkNames   | Resolver config keys to include                               |
+| `SYNC_CONFIG_RESOLVER_EXCLUDE`    | resolveIPv4,networkNames   | Resolver config keys to exclude                               |
+| `SYNC_CONFIG_DATABASE_INCLUDE`    | DBimport,maxDBdays         | Database config keys to include                               |
+| `SYNC_CONFIG_DATABASE_EXCLUDE`    | DBimport,maxDBdays         | Database config keys to exclude                               |
+| `SYNC_CONFIG_MISC_INCLUDE`        | nice,delay_startup         | Misc config keys to include                                   |
+| `SYNC_CONFIG_MISC_EXCLUDE`        | nice,delay_startup         | Misc config keys to exclude                                   |
+| `SYNC_CONFIG_DEBUG_INCLUDE`       | database,networking        | Debug config keys to include                                  |
+| `SYNC_CONFIG_DEBUG_EXCLUDE`       | database,networking        | Debug config keys to exclude                                  |
 
 ### Webhooks
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,13 @@ type Config struct {
 }
 
 type Sync struct {
-	FullSync        bool    `required:"true" envconfig:"FULL_SYNC"`
-	Cron            *string `                envconfig:"CRON"`
-	RunGravity      bool    `                envconfig:"RUN_GRAVITY" default:"false"`
-	GravitySettings *GravitySettings
-	ConfigSettings  *ConfigSettings  `                                                        ignored:"true"`
-	WebhookSettings *WebhookSettings `                                                        ignored:"true"`
+	FullSync          bool     `required:"true" envconfig:"FULL_SYNC"`
+	Cron              *string  `                envconfig:"CRON"`
+	RunGravity        bool     `                envconfig:"RUN_GRAVITY"                     default:"false"`
+	ExcludeDNSRecords []string `                envconfig:"SYNC_CONFIG_DNS_EXCLUDE_RECORDS"`
+	GravitySettings   *GravitySettings
+	ConfigSettings    *ConfigSettings  `                                                                            ignored:"true"`
+	WebhookSettings   *WebhookSettings `                                                                            ignored:"true"`
 }
 
 type GravitySettings struct {

--- a/internal/sync/full.go
+++ b/internal/sync/full.go
@@ -20,7 +20,7 @@ func (target *target) full(conf *config.Sync) error {
 		return fmt.Errorf("sync teleporters: %w", err)
 	}
 
-	if err := target.syncConfigs(configSettings); err != nil {
+	if err := target.syncConfigs(configSettings, conf.ExcludeDNSRecords); err != nil {
 		return fmt.Errorf("sync configs: %w", err)
 	}
 

--- a/internal/sync/selective.go
+++ b/internal/sync/selective.go
@@ -17,7 +17,7 @@ func (target *target) selective(conf *config.Sync) error {
 		return fmt.Errorf("sync teleporters: %w", err)
 	}
 
-	if err := target.syncConfigs(conf.ConfigSettings); err != nil {
+	if err := target.syncConfigs(conf.ConfigSettings, conf.ExcludeDNSRecords); err != nil {
 		return fmt.Errorf("sync configs: %w", err)
 	}
 


### PR DESCRIPTION
I added a feature to exclude specific DNS records from sync. Via the env files there can now be set a list of domain records, they will be excluded from sync. Also the set records on the replica remain unaffected and are therefore not deleted.