### PR TITLE
fix: stop packing binaries with UPX

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,12 +30,9 @@ builds:
       - goos: windows
         goarch: arm
 
+# UPX-packed Go binaries SIGSEGV on some NAS kernels (Docker exit 139).
 upx:
-  - enabled: true
-    goos: [linux]
-    compress: best
-    lzma: true
-    brute: true
+  - enabled: false
 
 archives:
   - formats: ['tar.gz']

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.26-alpine AS golang
 
 WORKDIR /app
 
-RUN apk add -U tzdata upx && \
-    apk --update add ca-certificates
+# Do not pack the binary with UPX. Packed Go binaries SIGSEGV on some NAS
+# kernels (notably Synology DSM) which surfaces as Docker exit code 139.
+RUN apk add --no-cache tzdata ca-certificates
 
 COPY . .
 
@@ -12,13 +13,12 @@ RUN go mod verify
 
 ARG VERSION=dev
 
-ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOOS=linux
-ENV GOFLAGS="-a -trimpath -ldflags=-w -ldflags=-s -ldflags=-X=github.com/lovelaze/nebula-sync/version.Version=${VERSION} -o=nebula-sync"
 
-RUN go build . && \
-    upx -q nebula-sync
+RUN go build -trimpath \
+    -ldflags="-s -w -X github.com/lovelaze/nebula-sync/version.Version=${VERSION}" \
+    -o nebula-sync .
 
 FROM scratch
 


### PR DESCRIPTION
## Summary

UPX-compressed Go binaries SIGSEGV on some NAS kernels, including Synology DSM. That shows up as Docker exit code 139 with no logs (#237).

This leaves the binary unpacked in the Docker image and disables UPX in goreleaser Linux builds.

Fixes #237

## Test plan

- [x] Confirmed `Dockerfile` no longer installs or runs `upx`
- [x] Confirmed `.goreleaser.yaml` has `upx.enabled: false`
- Image rebuild on Synology was not run here (no Docker daemon in this environment)