### PR TITLE
fix: harden HTTP client and session teardown after gravity

### DIFF
--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -28,16 +28,23 @@ func (c *Config) loadClient() error {
 }
 
 func (c *Client) NewHTTPClient() *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := cloneDefaultTransport()
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: c.SkipTLSVerification, //nolint:gosec // G402: opt-in for self-signed Pi-hole certs
+		InsecureSkipVerify: c.SkipTLSVerification,
 	}
 
 	return &http.Client{
 		Timeout:   time.Duration(c.Timeout) * time.Second,
 		Transport: transport,
 	}
+}
+
+func cloneDefaultTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		return base.Clone()
+	}
+	return &http.Transport{Proxy: http.ProxyFromEnvironment}
 }
 
 func (c *Client) String() string {

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -28,11 +28,15 @@ func (c *Config) loadClient() error {
 }
 
 func (c *Client) NewHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: c.SkipTLSVerification, //nolint:gosec // G402: opt-in for self-signed Pi-hole certs
+	}
+
 	return &http.Client{
-		Timeout: time.Duration(c.Timeout) * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SkipTLSVerification},
-		},
+		Timeout:   time.Duration(c.Timeout) * time.Second,
+		Transport: transport,
 	}
 }
 

--- a/internal/config/client_test.go
+++ b/internal/config/client_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/tls"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,4 +22,16 @@ func TestConfig_LoadClient(t *testing.T) {
 	assert.True(t, conf.Client.SkipTLSVerification)
 	assert.Equal(t, int64(45), conf.Client.Timeout)
 	assert.Equal(t, int64(5), conf.Client.RetryDelay)
+}
+
+func TestClient_NewHTTPClient_TLSMinVersion(t *testing.T) {
+	client := &Client{SkipTLSVerification: false, Timeout: 20}
+
+	httpClient := client.NewHTTPClient()
+	transport, ok := httpClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.NotNil(t, transport.Proxy)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,7 +209,13 @@ func (s *Sync) loadConfigSettings() error {
 }
 
 func (c *Config) String() string {
-	return fmt.Sprintf("%+v", *c)
+	replicas := make([]string, 0, len(c.Replicas))
+	for i := range c.Replicas {
+		replicas = append(replicas, c.Replicas[i].String())
+	}
+
+	return fmt.Sprintf("{Primary:%s Replicas:%s Client:%+v Sync:%+v API:%+v}",
+		c.Primary.String(), replicas, c.Client, c.Sync, c.API)
 }
 
 func (s *Sync) String() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -192,3 +192,19 @@ func TestConfig_NewConfigSetting(t *testing.T) {
 	assert.Equal(t, filter.Exclude, exclude.Filter.Type)
 	assert.Equal(t, []string{"key1", "key2"}, exclude.Filter.Keys)
 }
+
+func TestConfig_String_OmitsPasswords(t *testing.T) {
+	conf := Config{}
+	t.Setenv("PRIMARY", "http://localhost:1337|super-secret")
+	t.Setenv("REPLICAS", "http://localhost:1338|also-secret")
+	t.Setenv("FULL_SYNC", "false")
+
+	err := conf.Load()
+	require.NoError(t, err)
+
+	got := conf.String()
+	assert.NotContains(t, got, "super-secret")
+	assert.NotContains(t, got, "also-secret")
+	assert.Contains(t, got, "http://localhost:1337")
+	assert.Contains(t, got, "http://localhost:1338")
+}

--- a/internal/config/target.go
+++ b/internal/config/target.go
@@ -49,9 +49,9 @@ func loadReplicas() ([]model.PiHole, error) {
 			return nil, err
 		}
 
-		return parseMultiple(strings.Split(strings.TrimSpace(string(bytes)), ","))
+		return parseMultiple(splitReplicaList(strings.TrimSpace(string(bytes))))
 	} else if envValue := os.Getenv(env); len(envValue) > 0 {
-		return parseMultiple(strings.Split(envValue, ","))
+		return parseMultiple(splitReplicaList(envValue))
 	}
 
 	return nil, fmt.Errorf("missing required env: %s/%s_FILE", env, env)
@@ -68,7 +68,7 @@ func parse(value string) (*model.PiHole, error) {
 func parseMultiple(values []string) ([]model.PiHole, error) {
 	replicas := []model.PiHole{}
 	for _, value := range values {
-		ph, err := parse(value)
+		ph, err := parse(strings.TrimSpace(value))
 		if err != nil {
 			return nil, err
 		}
@@ -76,4 +76,40 @@ func parseMultiple(values []string) ([]model.PiHole, error) {
 		replicas = append(replicas, *ph)
 	}
 	return replicas, nil
+}
+
+// splitReplicaList splits REPLICAS on commas that start a new URL, so passwords
+// may contain commas without breaking the list (http://host|a,b,http://host2|c).
+func splitReplicaList(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	replicas := make([]string, 0, len(parts))
+	var current strings.Builder
+
+	for _, part := range parts {
+		if current.Len() == 0 {
+			current.WriteString(part)
+			continue
+		}
+
+		trimmed := strings.TrimSpace(part)
+		if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+			replicas = append(replicas, current.String())
+			current.Reset()
+			current.WriteString(part)
+			continue
+		}
+
+		current.WriteByte(',')
+		current.WriteString(part)
+	}
+
+	if current.Len() > 0 {
+		replicas = append(replicas, current.String())
+	}
+
+	return replicas
 }

--- a/internal/config/target_test.go
+++ b/internal/config/target_test.go
@@ -60,6 +60,30 @@ func TestConfig_Load_NoPrimary(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSplitReplicaList_PasswordWithComma(t *testing.T) {
+	got := splitReplicaList("http://localhost:1338|foo,bar,https://localhost:1339|baz")
+	require.Len(t, got, 2)
+	assert.Equal(t, "http://localhost:1338|foo,bar", got[0])
+	assert.Equal(t, "https://localhost:1339|baz", got[1])
+}
+
+func TestConfig_Load_ReplicaPasswordWithComma(t *testing.T) {
+	conf := Config{}
+
+	t.Setenv("PRIMARY", "http://localhost:1337|asdf")
+	t.Setenv("REPLICAS", "http://localhost:1338|foo,bar,http://localhost:1339|baz")
+	require.Empty(t, os.Getenv("PRIMARY_FILE"))
+	require.Empty(t, os.Getenv("REPLICAS_FILE"))
+
+	err := conf.loadTargets()
+	require.NoError(t, err)
+	require.Len(t, conf.Replicas, 2)
+	assert.Equal(t, "http://localhost:1338", conf.Replicas[0].URL.String())
+	assert.Equal(t, "foo,bar", conf.Replicas[0].Password)
+	assert.Equal(t, "http://localhost:1339", conf.Replicas[1].URL.String())
+	assert.Equal(t, "baz", conf.Replicas[1].Password)
+}
+
 func TestConfig_Load_NoReplicas(t *testing.T) {
 	conf := Config{}
 

--- a/internal/pihole/model/pihole.go
+++ b/internal/pihole/model/pihole.go
@@ -42,9 +42,22 @@ func (ph *PiHole) Decode(value string) error {
 		return fmt.Errorf("parse url: %w", err)
 	}
 
+	stripLegacyAdminPath(parsedURL)
+
 	*ph = PiHole{
 		URL:      parsedURL,
 		Password: password,
 	}
 	return nil
+}
+
+// stripLegacyAdminPath removes /admin and /admin/login suffixes that users often
+// copy from the Pi-hole web UI. The v6 API lives at /api on the same origin, so
+// joining those paths produces /admin/login/api/auth and auth fails.
+func stripLegacyAdminPath(u *url.URL) {
+	path := strings.TrimSuffix(u.Path, "/")
+	if strings.EqualFold(path, "/admin") || strings.EqualFold(path, "/admin/login") {
+		u.Path = ""
+		u.RawPath = ""
+	}
 }

--- a/internal/pihole/model/pihole_test.go
+++ b/internal/pihole/model/pihole_test.go
@@ -23,3 +23,26 @@ func TestPiHole_Decode(t *testing.T) {
 	assert.Equal(t, expectedURL, ph.URL)
 	assert.Equal(t, pw, ph.Password)
 }
+
+func TestPiHole_Decode_StripsLegacyAdminPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "admin", in: "https://dns.example/admin|secret", want: "https://dns.example"},
+		{name: "admin login", in: "https://dns.example/admin/login|secret", want: "https://dns.example"},
+		{name: "admin trailing slash", in: "https://dns.example/admin/|secret", want: "https://dns.example"},
+		{name: "custom path kept", in: "https://dns.example/pihole|secret", want: "https://dns.example/pihole"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ph := PiHole{}
+			err := ph.Decode(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, ph.URL.String())
+			assert.Equal(t, "secret", ph.Password)
+		})
+	}
+}

--- a/internal/sync/retry/retry.go
+++ b/internal/sync/retry/retry.go
@@ -15,7 +15,8 @@ const (
 	AttemptsPatchConfig    = 5
 	AttemptsPostRunGravity = 5
 	AttemptsPostAuth       = 3
-	AttemptsDeleteSession  = 3
+	// FTL often restarts after gravity, so session teardown needs more attempts.
+	AttemptsDeleteSession = 12
 )
 
 var delay time.Duration

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -67,7 +67,9 @@ func (target *target) authenticate() error {
 
 func (target *target) deleteSessions() {
 	log.Info().Msg("Invalidating sessions...")
-	if err := target.Primary.DeleteSession(); err != nil {
+	if err := retry.Fixed(func() error {
+		return target.Primary.DeleteSession()
+	}, retry.AttemptsDeleteSession); err != nil {
 		log.Warn().Msgf("Failed to invalidate session for target: %s", target.Primary.String())
 	}
 

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -34,16 +34,23 @@ func NewClient(c *config.WebhookSettings) *Client {
 }
 
 func newHTTPClient(skipTLSVerification bool) *http.Client {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := cloneDefaultTransport()
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: skipTLSVerification, //nolint:gosec // G402: opt-in for self-signed webhook endpoints
+		InsecureSkipVerify: skipTLSVerification,
 	}
 
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
 	}
+}
+
+func cloneDefaultTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		return base.Clone()
+	}
+	return &http.Transport{Proxy: http.ProxyFromEnvironment}
 }
 
 func (c *Client) OnSuccess() {

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -27,14 +27,22 @@ type Client struct {
 
 func NewClient(c *config.WebhookSettings) *Client {
 	return &Client{
-		success: c.Success,
-		failure: c.Failure,
-		httpClient: &http.Client{
-			Timeout: timeout,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: c.Client.SkipTLSVerification},
-			},
-		},
+		success:    c.Success,
+		failure:    c.Failure,
+		httpClient: newHTTPClient(c.Client.SkipTLSVerification),
+	}
+}
+
+func newHTTPClient(skipTLSVerification bool) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: skipTLSVerification, //nolint:gosec // G402: opt-in for self-signed webhook endpoints
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Clone `http.DefaultTransport` so TLS 1.2 is required and HTTP(S) proxies still work. The previous custom transport used Go zero values (no proxy, no idle timeouts).
- Retry session delete on the **primary** as well as replicas, and increase delete attempts. After `RUN_GRAVITY`, FTL restarts and HTTPS replicas often refuse connections for several seconds (#233).
- Strip `/admin` and `/admin/login` from configured URLs. Copying the web UI address produced `/admin/login/api/auth` and auth failed (#245).
- Split `REPLICAS` on URL boundaries so passwords may contain commas.
- Redact Pi-hole passwords from `Config.String()` debug dumps.

Fixes #233
Fixes #245

## Test plan

- [x] `go test -count=1 ./internal/config ./internal/pihole/model ./internal/sync ./internal/sync/retry ./internal/webhook`
- [x] New tests for TLS min version, `/admin/login` stripping, comma-in-password replica split, and password redaction
- Live HTTPS sync with `RUN_GRAVITY=true` was not run here