### PR TITLE
fix: keep cron running when the initial sync fails

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -20,6 +20,8 @@ type Service struct {
 	conf      config.Config
 	callbacks []sync.Callback
 	State     *sync.State
+	// runCron starts the scheduler. Tests replace it so Run() does not block.
+	runCron func(*cron.Cron)
 }
 
 func NewService(target sync.Target, conf config.Config, callbacks ...sync.Callback) *Service {
@@ -31,6 +33,7 @@ func NewService(target sync.Target, conf config.Config, callbacks ...sync.Callba
 		conf:      conf,
 		callbacks: cbs,
 		State:     state,
+		runCron:   func(c *cron.Cron) { c.Run() },
 	}
 }
 
@@ -67,7 +70,10 @@ func (service *Service) Run() error {
 	log.Debug().Str("config", service.conf.String()).Msgf("Settings")
 
 	if err := service.sync(service.target); err != nil {
-		return err
+		if service.conf.Sync.Cron == nil {
+			return err
+		}
+		log.Error().Err(err).Msg("Initial sync failed, continuing on cron schedule")
 	}
 
 	if service.conf.Sync.Cron != nil {
@@ -115,6 +121,6 @@ func (service *Service) startCron(cmd func()) error {
 		return fmt.Errorf("cron job: %w", err)
 	}
 
-	cron.Run()
+	service.runCron(cron)
 	return nil
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/lovelaze/nebula-sync/internal/config"
@@ -108,6 +109,32 @@ func TestRun_webhook_failure(t *testing.T) {
 	target.AssertCalled(t, "SelectiveSync", conf.Sync)
 	callback.AssertCalled(t, "OnFailure", syncErr)
 	callback.AssertNotCalled(t, "OnSuccess")
+}
+
+func TestRun_cron_continues_after_initial_failure(t *testing.T) {
+	cronExpr := "@hourly"
+	syncErr := errors.New("replica unreachable")
+	conf := config.Config{
+		Primary:  model.PiHole{},
+		Replicas: []model.PiHole{},
+		Sync: &config.Sync{
+			FullSync: true,
+			Cron:     &cronExpr,
+		},
+	}
+
+	target := syncmock.NewTarget(t)
+	callback := syncmock.NewCallback(t)
+	target.On("FullSync", conf.Sync).Return(syncErr)
+	callback.On("OnFailure", syncErr).Return(nil)
+
+	service := NewService(target, conf, callback)
+	service.runCron = func(*cron.Cron) {}
+
+	err := service.Run()
+	require.NoError(t, err)
+	target.AssertCalled(t, "FullSync", conf.Sync)
+	callback.AssertCalled(t, "OnFailure", syncErr)
 }
 
 func TestRun_webhook_error_does_not_affect_result(t *testing.T) {


### PR DESCRIPTION
## Summary

When `CRON` is set, a failed *first* sync currently exits the process. Docker restart-loops instead of waiting for the next tick. Later cron ticks already log sync errors and continue.

If a replica is down at startup, log the failure and still start the scheduler.

Fixes #156

## Test plan

- [x] `go test -count=1 ./internal/service ./internal/config ./internal/sync`
- [x] New test: `FullSync` error + `CRON=@hourly` → `Run()` returns nil